### PR TITLE
Update BetterTouchTools v1.47d download URL

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -9,7 +9,7 @@ cask 'bettertouchtool' do
   else
     version '1.47d'
     sha256 '81b15b17a13018e48edb796f972732d379f22b9f0601300899fea3d77162bc5e'
-    url "http://boastr.net/releases/btt#{version}.zip"
+    url "http://bettertouchtool.com/releases/btt#{version}.zip"
   end
 
   appcast 'http://appcast.boastr.net'


### PR DESCRIPTION
Dead link: http://boastr.net/releases/btt1.47d.zip
Correct link: http://bettertouchtool.com/releases/btt1.47d.zip